### PR TITLE
Add new file Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+PREFIX = /usr/local
+
+.PHONY : compile
+compile:
+	swift build --disable-sandbox -c release
+
+.PHONY : install
+install: compile
+	sudo mkdir -p $(PREFIX)/bin
+	sudo cp -p ./.build/release/monch $(PREFIX)/bin

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,6 @@ PREFIX = "/usr/local"
 
 desc "Install MonchCLI"
 task :install => :compile do
-  sh "mkdir -p #{PREFIX}/bin"
+  sh "sudo mkdir -p #{PREFIX}/bin"
   sh "sudo cp -p ./.build/release/monch #{PREFIX}/bin"
 end


### PR DESCRIPTION
because 'make' command is prepared by default,
even though 'rake' command should be installed by user.