### PR TITLE
Fix bug to show correct error message if required property is missing in .monch.json

### DIFF
--- a/Sources/MonchCLI/Domain/ValueObject/Config.swift
+++ b/Sources/MonchCLI/Domain/ValueObject/Config.swift
@@ -41,7 +41,7 @@ extension Config {
 
         func validate() throws {
             guard !token.isEmpty       else { throw(ConfigFileError.gitHubTokenEmpty) }
-            guard token.isAlphaNumeric else { throw(ConfigFileError.gitHubTokenEmpty) }
+            guard token.isAlphaNumeric else { throw(ConfigFileError.gitHubTokenWrongCharacter) }
             return
         }
     }

--- a/Sources/MonchCLI/Domain/ValueObject/Config.swift
+++ b/Sources/MonchCLI/Domain/ValueObject/Config.swift
@@ -12,10 +12,12 @@ struct Config {
     let github: Github
     let reviewers: [Reviewer]
 
-    func isValid() -> Bool {
-        chatwork.isValid()
-            && github.isValid()
-            && reviewers.reduce(true) { $0 && $1.isValid() }
+    func validate() throws {
+        try chatwork.validate()
+        try github.validate()
+        try reviewers.forEach {
+            try $0.validate()
+        }
     }
 }
 
@@ -24,14 +26,10 @@ extension Config {
         let token: String
         let roomId: Int
 
-        func isValid() -> Bool {
-            guard !token.isEmpty else {
-                fatalError("Chatwork Token が空です。設定ファイルを確認してください。")
-            }
-            guard token.isAlphaNumeric else {
-                fatalError("Chatwork Token はアルファベットと数字の組み合わせです。設定ファイルを確認してください。")
-            }
-            return true
+        func validate() throws {
+            guard !token.isEmpty       else { throw(ConfigFileError.chatworkTokenEmpty) }
+            guard token.isAlphaNumeric else { throw(ConfigFileError.chatworkTokenWrongCharacter) }
+            return
         }
     }
 }
@@ -41,14 +39,10 @@ extension Config {
         let token: String
         let repository: String
 
-        func isValid() -> Bool {
-            guard !token.isEmpty else {
-                fatalError("GitHub Token が空です。設定ファイルを確認してください。")
-            }
-            guard token.isAlphaNumeric else {
-                fatalError("GitHub Token はアルファベットと数字の組み合わせです。設定ファイルを確認してください。")
-            }
-            return true
+        func validate() throws {
+            guard !token.isEmpty       else { throw(ConfigFileError.gitHubTokenEmpty) }
+            guard token.isAlphaNumeric else { throw(ConfigFileError.gitHubTokenEmpty) }
+            return
         }
     }
 }

--- a/Sources/MonchCLI/Domain/ValueObject/ExitCode.swift
+++ b/Sources/MonchCLI/Domain/ValueObject/ExitCode.swift
@@ -1,0 +1,21 @@
+//
+//  ExitCode.swift
+//  MonchCLI
+//
+//  Created by 安宅正之 on 2020/06/20.
+//
+
+import Foundation
+
+enum ExitCode: Int32, Error {
+    case success
+    case invalidConfigFile
+}
+
+func exit(_ exitCode: ExitCode) -> Never {
+    switch exitCode {
+    case .success: exit(EXIT_SUCCESS)
+    default:
+        exit(exitCode.rawValue)
+    }
+}

--- a/Sources/MonchCLI/Domain/ValueObject/Reviewer.swift
+++ b/Sources/MonchCLI/Domain/ValueObject/Reviewer.swift
@@ -14,14 +14,10 @@ struct Reviewer: Hashable, Decodable {
 
     // MARK: - Domain Logic
 
-    func isValid() -> Bool {
-        guard !name.isEmpty else {
-            fatalError("Reviewer の名前が空です。設定ファイルを確認してください。")
-        }
-        guard !githubLogin.isEmpty else {
-            fatalError("Reviewer の GitHub の名前が空です。設定ファイルを確認してください。")
-        }
-        return true
+    func validate() throws {
+        guard !name.isEmpty        else { throw(ConfigFileError.reviewerNameEmpty) }
+        guard !githubLogin.isEmpty else { throw(ConfigFileError.reviewerGitHubLoginEmpty) }
+        return
     }
 
     typealias FilterClosure = (_ reviewer: Self) -> Bool

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileError.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileError.swift
@@ -9,6 +9,17 @@ import Foundation
 
 enum ConfigFileError: Error {
     case noProperty(name: String)
+    // MARK: Chatwork
+    case chatworkTokenEmpty
+    case chatworkTokenWrongCharacter
+    // MARK: GitHub
+    case gitHubTokenEmpty
+    case gitHubTokenWrongCharacter
+    // MARK: Reviewer
+    case reviewerNameEmpty
+    case reviewerGitHubLoginEmpty
+
+    // MARK: - Localized Description
 
     var localizedDescription: String {
         switch self {
@@ -19,6 +30,18 @@ enum ConfigFileError: Error {
 
             設定されていないプロパティー: \(propertyName)
             """
+        case .chatworkTokenEmpty:
+            return "Chatwork Token が空です。設定ファイルを確認してください。"
+        case .chatworkTokenWrongCharacter:
+            return "Chatwork Token はアルファベットと数字の組み合わせです。設定ファイルを確認してください。"
+        case .gitHubTokenEmpty:
+            return "GitHub Token が空です。設定ファイルを確認してください。"
+        case .gitHubTokenWrongCharacter:
+            return "GitHub Token はアルファベットと数字の組み合わせです。設定ファイルを確認してください。"
+        case .reviewerNameEmpty:
+            return "Reviewer の名前が空です。設定ファイルを確認してください。"
+        case .reviewerGitHubLoginEmpty:
+            return "Reviewer の GitHub の名前が空です。設定ファイルを確認してください。"
         }
     }
 }

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileError.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileError.swift
@@ -1,0 +1,24 @@
+//
+//  ConfigFileError.swift
+//  MonchCLI
+//
+//  Created by 安宅正之 on 2020/06/20.
+//
+
+import Foundation
+
+enum ConfigFileError: Error {
+    case noProperty(name: String)
+
+    var localizedDescription: String {
+        switch self {
+        case let .noProperty(name: propertyName):
+            return """
+            設定ファイル .monch.json で、次のプロパティーがセットされていないようです。
+            設定ファイルを確認してください。
+
+            設定されていないプロパティー: \(propertyName)
+            """
+        }
+    }
+}

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileObject.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileObject.swift
@@ -132,7 +132,7 @@ private func checkNil<T>(_ x: T, labels: [String] = []) -> Bool {
                 設定ファイル .monch.json で、次のプロパティーがセットされていないようです。
                 設定ファイルを確認してください。
 
-                設定されていないプロパティー: (newLabels.joined(separator: ".")
+                設定されていないプロパティー: \(newLabels.joined(separator: "."))
                 """
                 fatalError(message)
             }

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileObject.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileObject.swift
@@ -99,7 +99,7 @@ struct GithubFileObject: Decodable {
 
 extension Config {
     init(configFileObject obj: ConfigFileObject) throws {
-            try checkNil(obj)
+        try checkNil(obj)
         self.init(
             chatwork: Chatwork(
                 token: obj.chatwork!.token!,

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileObject.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileObject.swift
@@ -98,8 +98,8 @@ struct GithubFileObject: Decodable {
 }
 
 extension Config {
-    init(configFileObject obj: ConfigFileObject) {
-        guard checkNil(obj) else { fatalError("BANG!") }
+    init(configFileObject obj: ConfigFileObject) throws {
+        _ = try checkNil(obj)
         self.init(
             chatwork: Chatwork(
                 token: obj.chatwork!.token!,
@@ -114,27 +114,21 @@ extension Config {
     }
 }
 
-private func checkNil<T>(_ x: T, labels: [String] = []) -> Bool {
+private func checkNil<T>(_ x: T, labels: [String] = []) throws -> Bool {
     let mirror = Mirror(reflecting: x)
     guard let displayStyle = mirror.displayStyle else { return true }
 
     switch displayStyle {
     case .optional:
         guard let unwrappedValue = mirror.children.first?.value else { return false }
-        return checkNil(unwrappedValue, labels: labels)
+        return try checkNil(unwrappedValue, labels: labels)
     case .collection:
         return !mirror.children.isEmpty
     default:
-        return mirror.children.reduce(true) {
+        return try mirror.children.reduce(true) {
             let newLabels = labels + [ $1.label!]
-            guard checkNil($1.value, labels: newLabels) else {
-                let message = """
-                設定ファイル .monch.json で、次のプロパティーがセットされていないようです。
-                設定ファイルを確認してください。
-
-                設定されていないプロパティー: \(newLabels.joined(separator: "."))
-                """
-                fatalError(message)
+            guard try checkNil($1.value, labels: newLabels) else {
+                throw(ConfigFileError.noProperty(name: newLabels.joined(separator: ".")))
             }
             return $0
         }

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileObject.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigFileObject.swift
@@ -126,7 +126,7 @@ private func checkNil<T>(_ x: T, labels: [String] = []) throws -> Bool {
         return !mirror.children.isEmpty
     default:
         return try mirror.children.reduce(true) {
-            let newLabels = labels + [ $1.label!]
+            let newLabels = labels + [$1.label!]
             guard try checkNil($1.value, labels: newLabels) else {
                 throw(ConfigFileError.noProperty(name: newLabels.joined(separator: ".")))
             }

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigRepository.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigRepository.swift
@@ -12,7 +12,7 @@ struct ConfigRepository {
         do {
             let configFileObject = try ConfigFileObject.paths
                 .lazy
-                .filter { FileManager.default.fileExists(atPath: $0) }
+                .filter(FileManager.default.fileExists(atPath:))
                 .map { try ConfigFileObjectFactory.make(path: $0) }
                 .reduce(ConfigFileObject.empty) { $0.merging($1) }
 

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigRepository.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigRepository.swift
@@ -16,9 +16,12 @@ struct ConfigRepository {
                 .map { try ConfigFileObjectFactory.make(path: $0) }
                 .reduce(ConfigFileObject.empty) { $0.merging($1) }
 
-            let config = Config(configFileObject: configFileObject)
+            let config = try Config(configFileObject: configFileObject)
             guard config.isValid() else { fatalError("BANG") }
             return config
+        } catch let error as ConfigFileError {
+            print(error.localizedDescription)
+            exit(.invalidConfigFile)
         } catch {
             fatalError(error.localizedDescription)
         }

--- a/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigRepository.swift
+++ b/Sources/MonchCLI/Infrastructure/Repository/ConfigRepository/ConfigRepository.swift
@@ -17,7 +17,7 @@ struct ConfigRepository {
                 .reduce(ConfigFileObject.empty) { $0.merging($1) }
 
             let config = try Config(configFileObject: configFileObject)
-            guard config.isValid() else { fatalError("BANG") }
+            try config.validate()
             return config
         } catch let error as ConfigFileError {
             print(error.localizedDescription)


### PR DESCRIPTION
Use `exit()` instead of `fatalError()` to make the error message clean.