### PR TITLE
Follow the update of GitHub authentication token format

### DIFF
--- a/Sources/MonchCLI/Domain/ValueObject/Config.swift
+++ b/Sources/MonchCLI/Domain/ValueObject/Config.swift
@@ -44,9 +44,14 @@ extension Config {
         let repository: String
 
         func validate() throws {
-            guard !token.isEmpty       else { throw(ConfigFileError.gitHubTokenEmpty) }
-            guard token.isAlphaNumeric else { throw(ConfigFileError.gitHubTokenWrongCharacter) }
+            guard !token.isEmpty      else { throw(ConfigFileError.gitHubTokenEmpty) }
+            guard isValidToken(token) else { throw(ConfigFileError.gitHubTokenWrongCharacter) }
             return
+        }
+
+        // https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/
+        private func isValidToken(_ token: String) -> Bool {
+            token.range(of: "[^A-Za-z0-9_]", options: .regularExpression) == nil
         }
     }
 }


### PR DESCRIPTION
- https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/

Changed from 'a-f0-9' to 'A-Za-z0-9_'.