### PR TITLE
Encode query string with percent encoding

### DIFF
--- a/Sources/MonchCLI/Infrastructure/APIClient/Chatwork/XWWWFormUrlEncoder.swift
+++ b/Sources/MonchCLI/Infrastructure/APIClient/Chatwork/XWWWFormUrlEncoder.swift
@@ -17,9 +17,18 @@ final class XWWWFormUrlEncoder {
 
     private func format(from keyValues: [String: String]) -> Data {
         keyValues
-            .map { (key, value) in "\(key)=\(value)" }
+            .map { (key, value) in "\(key)=\(value.urlEncoded)" }
             .joined(separator: "&")
             .data(using: .utf8)!
+    }
+}
+
+// refs. https://dev.classmethod.jp/articles/urlencode-spec-and-implementation-for-swift/
+private extension String {
+    var urlEncoded: String {
+        let charset = CharacterSet.alphanumerics.union(.init(charactersIn: "/?-._~"))
+        let removed = removingPercentEncoding ?? self
+        return removed.addingPercentEncoding(withAllowedCharacters: charset) ?? removed
     }
 }
 


### PR DESCRIPTION
Fix bug that reported in https://github.com/ataka/MonchCLI/issues/19